### PR TITLE
Add setup script and update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ ENV/
 # mkdocs documentation
 /site
 
+# allow build setup script
+!build/setup_env.py
+

--- a/README.md
+++ b/README.md
@@ -88,3 +88,18 @@ The command vocabulary can be extended without modifying the code. Edit
 [grammar_config.json](grammar_config.json) to add new keywords for actions such
 as movement or fighting. The game now also supports commands like `look door`
 to inspect a specific object that is present in the current area.
+
+### Running the game
+
+Before starting the game for the first time you may need to install the Python
+dependencies and the required NLTK datasets. A helper script is provided:
+
+```bash
+python build/setup_env.py
+```
+
+After the script completes you can launch the game with:
+
+```bash
+python zork.py
+```

--- a/build/setup_env.py
+++ b/build/setup_env.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Install required packages and NLTK datasets for pyzork.
+
+Running this script will ensure that the `nltk` package is installed and that the
+required NLTK data files are present in the local ``nltk_data`` directory.
+After executing it you should be able to start the game with ``python zork.py``.
+"""
+
+import importlib
+import os
+import subprocess
+import sys
+
+
+def ensure_package(pkg_name: str) -> None:
+    """Ensure that a package is installed via pip."""
+    try:
+        importlib.import_module(pkg_name)
+    except ImportError:
+        subprocess.check_call([sys.executable, "-m", "pip", "install", pkg_name])
+
+
+def ensure_nltk_data() -> None:
+    """Download NLTK resources used by the game if they are missing."""
+    import nltk  # noqa: E402 - imported after ensure_package
+
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    data_dir = os.path.join(repo_root, "nltk_data")
+    os.makedirs(data_dir, exist_ok=True)
+    nltk.data.path.append(data_dir)
+
+    for resource in ["punkt", "stopwords"]:
+        try:
+            nltk.data.find(f"tokenizers/{resource}" if resource == "punkt" else f"corpora/{resource}")
+        except LookupError:
+            nltk.download(resource, download_dir=data_dir)
+
+
+def main() -> None:
+    ensure_package("nltk")
+    ensure_nltk_data()
+    print("All dependencies installed. You can now run zork.py")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a helper script to install nltk and the required datasets
- document how to run the setup script in the README
- allow tracking of the setup script in `.gitignore`

## Testing
- `pytest -q`
- `python build/setup_env.py`

------
https://chatgpt.com/codex/tasks/task_e_684044e60c2083218a4749bf2ecf49d7