### PR TITLE
Update codebase for modern Python

### DIFF
--- a/gameMap.py
+++ b/gameMap.py
@@ -1,23 +1,17 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, with_statement
 import json
-import sets
 import os
 import pickle
 import sys
+
 try:
-    import nltk, os
+    import nltk
     nltk.data.path.append(os.path.join(os.getcwd(), 'nltk_data'))
     from nltk import PorterStemmer
 except ImportError:
     print("You need NLTK installed to run this game.")
     sys.exit(0)
-
-try:
-    input = raw_input
-except NameError:
-    print("Cannot port input.")
 
 mapFile = "map.json"
 saveGameMapFile = "savedGameMap.dat"
@@ -50,16 +44,8 @@ alreadyKilled = "alreadyKilled"
 killed = "killed"
 end = "end"
 
-def byteify(data, ignore_dicts = False):
-    if isinstance(data, str):
-        return data.encode('utf-8')
-    if isinstance(data, list):
-        return [ byteify(item, ignore_dicts=True) for item in data ]
-    if isinstance(data, dict) and not ignore_dicts:
-        return {
-        byteify(key, ignore_dicts=True): byteify(value, ignore_dicts=True)
-        for key, value in data.items()
-        }
+def byteify(data, ignore_dicts=False):
+    """Compatibility shim from the old Python 2 implementation."""
     return data
 
 def clear():
@@ -86,9 +72,9 @@ def stem(word):
     return ps.stem(word)
 
 def saveGame(mapDict, playerInfo):
-    with open(saveGameMapFile, 'w') as f:
+    with open(saveGameMapFile, 'wb') as f:
         pickle.dump(mapDict, f)
-    with open(saveGamePlayerFile, 'w') as f:
+    with open(saveGamePlayerFile, 'wb') as f:
         playerState = (playerInfo.position, playerInfo.direction, playerInfo.have)
         pickle.dump(playerState, f)
 
@@ -112,8 +98,8 @@ class Map:
             self.fsm = mapDict
         else:
             try:
-                map_f = open(mapFile, 'r')
-                self.fsm = json.load(map_f, object_hook=byteify)
+                with open(mapFile, 'r') as map_f:
+                    self.fsm = json.load(map_f)
             except (IOError, OSError):
                 print("Cannot load game. Map file not found.")
                 sys.exit(0)

--- a/grammar.py
+++ b/grammar.py
@@ -25,7 +25,7 @@ GRAMMAR_CONFIG = os.path.join(os.path.dirname(__file__), 'grammar_config.json')
 with_ = "with"
 from_ = "from"
 help_ = "help"
-wildcard = "\_(**)_/"
+wildcard = r"\_(**)_/"
 
 what_next = ["What do you do? ", "What next? ", \
                 "What do you do next? "]

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -17,7 +17,6 @@ nltk_stub.word_tokenize = word_tokenize
 nltk_stub.corpus = types.SimpleNamespace(stopwords=types.SimpleNamespace(words=lambda lang: []))
 nltk_stub.data = types.SimpleNamespace(path=[])
 sys.modules.setdefault('nltk', nltk_stub)
-sys.modules.setdefault('sets', types.ModuleType('sets'))
 
 import player
 import gameMap

--- a/zork.py
+++ b/zork.py
@@ -18,13 +18,17 @@ import gameMap
 what_next = ["What do you do? ", "What next? ", \
                 "What do you do next? ", "What do you do now? ", "What is your next move? ", "What now?"]
 
-did_not_catch_that = ["Did not catch that.", "What was that?", "I don't understand that.", "Could you say that again?", "Repeat that?", "Sorry?",\
-		"Did not understand that?", "Say that again?", "My vocabulary is limited. Could you say that again?"]
-
-try:
-	input = raw_input
-except NameError:
-	print("Cannot port input.")
+did_not_catch_that = [
+        "Did not catch that.",
+        "What was that?",
+        "I don't understand that.",
+        "Could you say that again?",
+        "Repeat that?",
+        "Sorry?",
+        "Did not understand that?",
+        "Say that again?",
+        "My vocabulary is limited. Could you say that again?",
+]
 
 def sayDidNotCatchThat():
 	print(did_not_catch_that[random.randint(0, len(did_not_catch_that)-1)])


### PR DESCRIPTION
## Summary
- drop the obsolete `sets` import and Python 2 input stubs
- open pickle files in binary mode
- remove Python 2 byte conversion helper
- silence wildcard string warning
- adjust unit tests for updated imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840461d5708832187b5cb2c0d386274